### PR TITLE
feat: 퀴즈 세션 생성 API 연동 및 응답 처리 #4

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'screens/explore_screen.dart';
 import 'screens/current_intro_screen.dart';
+import 'screens/all_categories_screen.dart';
+import 'screens/quiz_session_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -18,6 +20,8 @@ class MyApp extends StatelessWidget {
       home: const HomeScreen(),
       routes: {
         '/intro': (context) => const CurrentIntroScreen(),
+        '/all-categories': (context) => const AllCategoriesScreen(),
+        '/quiz': (context) => const QuizSessionScreenWrapper(),
       },
     );
   }

--- a/lib/screens/current_intro_screen.dart
+++ b/lib/screens/current_intro_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'quiz_session_screen.dart';
 
 class CurrentIntroScreen extends StatefulWidget {
   const CurrentIntroScreen({super.key});
@@ -24,7 +25,7 @@ class _CurrentIntroScreenState extends State<CurrentIntroScreen> {
 
   Future<void> fetchCategoryIntro() async {
     final encodedName = Uri.encodeComponent(name);
-    final url = Uri.parse('http://localhost:5000/categories/name/$encodedName'); // 실제 IP로 변경 가능
+    final url = Uri.parse('http://10.0.2.2:5000/categories/name/$encodedName'); // 실제 IP로 변경 가능
 
     try {
       final response = await http.get(url);
@@ -50,75 +51,187 @@ class _CurrentIntroScreenState extends State<CurrentIntroScreen> {
     }
   }
 
+  Future<void> createQuizSession() async {
+    final categoryMap = {
+      '거시경제학': 1,
+      '국제경제·무역': 2,
+      '금융·투자': 3,
+      '기초 경제 개념': 4,
+      '미시경제학': 5,
+      '시사 상식': 6,
+      '행동경제학': 7,
+    };
+
+    final userId = 123; // 🔧 실제 유저 ID로 대체
+    final categoryId = categoryMap[name];
+
+    if (categoryId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('유효하지 않은 카테고리입니다.')),
+      );
+      return;
+    }
+
+    final url = Uri.parse('http://10.0.2.2:5000/quizzes/session');
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'categoryId': categoryId,
+        'userId': userId,
+      }),
+    );
+
+    if (response.statusCode == 201) {
+      final data = json.decode(response.body);
+      final sessionId = data['sessionId'];
+      final quizIds = List<String>.from(data['quizIds']);
+      Navigator.pushNamed(context, '/quiz', arguments: {
+        'sessionId': sessionId,
+        'quizIds': quizIds,
+      });
+    } else {
+      final error = json.decode(response.body)['error'] ?? '알 수 없는 오류';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('퀴즈 세션 생성 실패: $error')),
+      );
+    }
+  }
+
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFF7F9FC),
-      body: Stack(
+      body: Column(
         children: [
-          Positioned.fill(
-            child: Container(color: const Color(0xFFF7F9FC)),
-          ),
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black12,
-                    blurRadius: 12,
-                    offset: Offset(0, -4),
-                  ),
-                ],
-              ),
-              child: isLoading
-                  ? const Center(child: CircularProgressIndicator())
-                  : Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: const [
-                      Icon(Icons.arrow_back_ios, color: Colors.grey),
-                      Icon(Icons.bookmark_border, color: Colors.grey),
-                    ],
-                  ),
-                  const SizedBox(height: 20),
-                  Center(
-                    child: Text(
+          Expanded(
+            child: SingleChildScrollView(
+              child: Container(
+                constraints: BoxConstraints(
+                  minHeight: MediaQuery.of(context).size.height,
+                ),
+                padding: const EdgeInsets.fromLTRB(24, 60, 24, 0),
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black12,
+                      blurRadius: 12,
+                      offset: Offset(0, -4),
+                    ),
+                  ],
+                ),
+                child: isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 상단 아이콘
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.arrow_back_ios, color: Colors.grey),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                        const Icon(Icons.bookmark_border, color: Colors.grey),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
                       name,
                       style: const TextStyle(
-                        fontSize: 22,
+                        fontSize: 20,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    description,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 14),
-                  ),
-                  const SizedBox(height: 12),
-                  if (keywords.isNotEmpty)
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: keywords
-                          .map((k) => Chip(label: Text(k)))
-                          .toList(),
+                    const SizedBox(height: 8),
+                    Text(
+                      description,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        color: Color(0xff727272),
+                      ),
                     ),
-                ],
+                    const SizedBox(height: 28),
+                    const Text(
+                      "이런 내용을 다뤄요!",
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    if (keywords.isNotEmpty)
+                      Column(
+                        children: keywords.map((k) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 6),
+                            child: SizedBox(
+                              width: 334,
+                              height: 52,
+                              child: ElevatedButton(
+                                onPressed: () {},
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: const Color(0xffEAF2FF),
+                                  foregroundColor: Colors.black,
+                                  elevation: 0,
+                                  alignment: Alignment.centerLeft,
+                                  shape: RoundedRectangleBorder(
+                                   borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                                child: Text(
+                                k,
+                                style: const TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ),
+                        );
+                     }).toList(),
+                    ),
+
+                    const SizedBox(height: 60), // 버튼과의 여백 확보
+                  ],
+                ),
               ),
             ),
           ),
         ],
       ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 0, 20, 30),
+        child: SizedBox(
+          width: double.infinity,
+          height: 50,
+          child: ElevatedButton(
+            onPressed: () async {
+              await createQuizSession();
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xff006FFD),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            child: const Text(
+              '시작하기',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
+
 }

--- a/lib/screens/quiz_session_screen.dart
+++ b/lib/screens/quiz_session_screen.dart
@@ -1,0 +1,142 @@
+// quiz_session_screen.dart
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class QuizSessionScreen extends StatefulWidget {
+  final int sessionId;
+  final List<String> quizIds;
+
+  const QuizSessionScreen({
+    super.key,
+    required this.sessionId,
+    required this.quizIds,
+  });
+
+  @override
+  State<QuizSessionScreen> createState() => _QuizSessionScreenState();
+}
+
+class _QuizSessionScreenState extends State<QuizSessionScreen> {
+  int currentIndex = 0;
+  List<Map<String, dynamic>> quizData = [];
+  Map<int, String> userAnswers = {};
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchAllQuizzes();
+  }
+
+  Future<void> fetchAllQuizzes() async {
+    for (var id in widget.quizIds) {
+      final url = Uri.parse('http://10.0.2.2:5000/quizzes/$id');
+      final response = await http.get(url);
+      if (response.statusCode == 200) {
+        quizData.add(json.decode(response.body));
+      }
+    }
+    setState(() => isLoading = false);
+  }
+
+  void submitAll() async {
+    final url = Uri.parse('http://10.0.2.2:5000/quizzes/session/${widget.sessionId}/complete');
+    final answers = quizData.map((q) => {
+      'questionId': q['id'],
+      'selectedAnswer': userAnswers[q['id']] ?? '',
+    }).toList();
+
+    final response = await http.post(url,
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({'answers': answers}),
+    );
+
+
+    if (response.statusCode == 200) {
+      final result = json.decode(response.body);
+      // 결과 화면 이동
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final quiz = quizData[currentIndex];
+    final options = List<String>.from(quiz['options']);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('문제 ${currentIndex + 1} / ${quizData.length}'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              quiz['question'],
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+            ...options.map((opt) => RadioListTile<String>(
+              title: Text(opt),
+              value: opt,
+              groupValue: userAnswers[quiz['id']],
+              onChanged: (val) {
+                setState(() {
+                  userAnswers[quiz['id']] = val!;
+                });
+              },
+            )),
+            const Spacer(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: currentIndex > 0
+                      ? () => setState(() => currentIndex--)
+                      : null,
+                  child: const Text('이전'),
+                ),
+                currentIndex < quizData.length - 1
+                    ? ElevatedButton(
+                  onPressed: () => setState(() => currentIndex++),
+                  child: const Text('다음'),
+                )
+                    : ElevatedButton(
+                  onPressed: submitAll,
+                  child: const Text('제출'),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+}
+
+class QuizSessionScreenWrapper extends StatelessWidget {
+  const QuizSessionScreenWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final args = ModalRoute.of(context)!.settings.arguments as Map;
+    final sessionId = args['sessionId'] as int;
+    final quizIds = List<String>.from(args['quizIds']);
+
+    return QuizSessionScreen(
+      sessionId: sessionId,
+      quizIds: quizIds,
+    );
+  }
+}
+
+


### PR DESCRIPTION
- current_intro_screen.dart 추가
- quiz_session_screen.dart 추가
- main.dart 수정

1. current_intro_screen.dart에서 세션 생성 요청
사용자가 카테고리를 선택하고 '시작하기' 버튼을 누르면 createQuizSession() 실행 ▼
 /quizzes/session API에 `categoryId`와 `userId`를 POST 요청 ▼
응답으로 sessionId와 quizIds를 받아 `Navigator.pushNamed(context, '/quiz', arguments: {...})`로 퀴즈 화면으로 이동

2. 라우팅
main.dart에 /quiz 경로 등록 (QuizSessionScreenWrapper)

3. quiz_session_screen.dart에서 전달값 처리
QuizSessionScreenWrapper는 ModalRoute.of(context)!.settings.arguments로부터 `sessionId`와 `quizIds`를 받아 QuizSessionScreen에 넘김 ▼
quizIds로 받은 퀴즈들을 다시 GET 요청 → 개별 요청으로 받아 문제 출력
마지막 문제에서 `submitAll()`을 통해 /session/:id/complete로 응답 제출

