### PR TITLE
feat: 오늘의 퀴즈 완료 시 뱃지 전환 콜백 연동 #32

### DIFF
--- a/lib/screens/quiz_session_screen.dart
+++ b/lib/screens/quiz_session_screen.dart
@@ -6,11 +6,15 @@ import 'package:http/http.dart' as http;
 class QuizSessionScreen extends StatefulWidget {
   final int sessionId;
   final List<int> quizIds;
+  final bool isDaily;
+  final VoidCallback? onComplete;
 
   const QuizSessionScreen({
     super.key,
     required this.sessionId,
     required this.quizIds,
+    this.isDaily = false,
+    this.onComplete, // 오늘의 퀴즈 완료 상태 전환하는 콜백 함수
   });
 
   @override
@@ -67,6 +71,12 @@ class _QuizSessionScreenState extends State<QuizSessionScreen> {
 
     if (response.statusCode == 200) {
       final result = json.decode(response.body);
+
+      // 정답 제출 후 결과 페이지로 넘어가기 전에
+      // 오늘의 퀴즈일 경우 완료 처리
+      if (widget.isDaily && widget.onComplete != null) {
+        widget.onComplete!();
+      }
 
       Navigator.pushReplacementNamed(context, '/result', arguments: {
         'sessionId': widget.sessionId,
@@ -242,7 +252,6 @@ class QuizSessionScreenWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final args = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
-    print('arguments: $args');
     if (args == null || args['sessionId'] == null || args['quizIds'] == null) {
       return const Scaffold(
         body: Center(child: Text('잘못된 접근입니다.')),
@@ -254,10 +263,14 @@ class QuizSessionScreenWrapper extends StatelessWidget {
         : args['sessionId'] as int;
 
     final List<int> quizIds = List<int>.from(args['quizIds']);
+    final bool isDaily = args['isDaily'] ?? false;
+    final VoidCallback? onComplete = args['onComplete'];
 
     return QuizSessionScreen(
       sessionId: sessionId,
       quizIds: quizIds,
+      isDaily: isDaily,
+      onComplete: onComplete,
     );
   }
 }

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -190,7 +190,7 @@ exports.completeSession = async (req, res) => {
     }
 
     await pool.query(
-      `UPDATE quiz_sessions SET completed = true WHERE session_id = $1`,
+      `UPDATE quiz_sessions SET is_completed = true WHERE session_id = $1`,
       [sessionId]
     );
 


### PR DESCRIPTION
오늘의 퀴즈를 풀어도 뱃지 상태가 '미완료'에서 '완료'로 전환되지 않는 문제가 있었음  

- /quiz 페이지에서 `isDaily`, `onComplete` 파라미터 처리
- 퀴즈 완료 시 onComplete() 호출로 daily_quiz_widget 상태 갱신